### PR TITLE
Merge dev → main: image FK fix, iterative refinement, deployment updates

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,6 +17,7 @@ from jose import JWTError, jwt
 from miniopy_async import Minio
 from openai import AsyncOpenAI
 from pydantic import BaseModel
+from typing import Optional
 from dotenv import load_dotenv
 
 # Load env vars if present
@@ -291,6 +292,7 @@ class ImageGenerateRequest(BaseModel):
     prompt: str
     width: int = 512
     height: int = 512
+    previous_image_url: Optional[str] = None
 
 
 # --- Streaming ---
@@ -660,6 +662,12 @@ async def image_describe(
         )
 
         await conn.execute(
+            """INSERT INTO conversations (id, user_id, title, messages, created_at, updated_at)
+               VALUES ($1, $2, 'New Conversation', '[]'::jsonb, NOW(), NOW())
+               ON CONFLICT (id) DO NOTHING""",
+            conversation_id, uid,
+        )
+        await conn.execute(
             """INSERT INTO image_generations
                (id, conversation_id, user_id, mode, source_image_key, status)
                VALUES ($1, $2, $3, 'image_to_text', $4, 'processing')""",
@@ -717,17 +725,52 @@ async def image_generate(
     async with pool.acquire() as conn:
         uid = await get_user_id(conn, user["username"])
         await conn.execute(
+            """INSERT INTO conversations (id, user_id, title, messages, created_at, updated_at)
+               VALUES ($1, $2, 'New Conversation', '[]'::jsonb, NOW(), NOW())
+               ON CONFLICT (id) DO NOTHING""",
+            body.conversation_id, uid,
+        )
+        await conn.execute(
             """INSERT INTO image_generations
                (id, conversation_id, user_id, mode, prompt, status)
                VALUES ($1, $2, $3, 'text_to_image', $4, 'processing')""",
             uuid.UUID(generation_id), body.conversation_id, uid, body.prompt,
         )
 
+    effective_prompt = body.prompt
+    if body.previous_image_url:
+        try:
+            async with httpx.AsyncClient(timeout=30) as http:
+                img_resp = await http.get(body.previous_image_url)
+                img_resp.raise_for_status()
+            prev_b64 = base64.b64encode(img_resp.content).decode()
+            vision_client = AsyncOpenAI(base_url=VISION_BASE_URL, api_key=VISION_API_KEY)
+            vision_resp = await vision_client.chat.completions.create(
+                model=VISION_MODEL,
+                messages=[{
+                    "role": "user",
+                    "content": [
+                        {"type": "image_url",
+                         "image_url": {"url": f"data:image/png;base64,{prev_b64}"}},
+                        {"type": "text",
+                         "text": (
+                             f"Describe this image in detail. The user wants to refine it with: "
+                             f"'{body.prompt}'. Write a comprehensive text-to-image generation prompt "
+                             f"that preserves the key visual elements of the original image and "
+                             f"incorporates the requested changes."
+                         )},
+                    ],
+                }],
+            )
+            effective_prompt = vision_resp.choices[0].message.content
+        except Exception:
+            effective_prompt = body.prompt
+
     try:
         async with httpx.AsyncClient(timeout=3600) as http:   # CPU can be slow
             resp = await http.post(
                 f"{IMAGE_SERVICE_URL}/generate",
-                json={"prompt": body.prompt, "width": body.width, "height": body.height},
+                json={"prompt": effective_prompt, "width": body.width, "height": body.height},
             )
             resp.raise_for_status()
         image_bytes = resp.content

--- a/deployment/chat-ui/deployment-chat-ui.yaml
+++ b/deployment/chat-ui/deployment-chat-ui.yaml
@@ -21,7 +21,7 @@ spec:
       containers:
       - name: container
         image: 'quay.io/mmartofe/ai-chat:latest'
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         ports:
         - containerPort: 8080
           protocol: TCP

--- a/deployment/chat-vllm/k8s/deployment.yaml
+++ b/deployment/chat-vllm/k8s/deployment.yaml
@@ -106,7 +106,7 @@ spec:
       containers:
         - name: server
           image: ${RHIIS_IMAGE}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           # RHAIIS image uses python -m entrypoint rather than the `vllm serve` CLI.
           command: ["python", "-m", "vllm.entrypoints.openai.api_server"]
           args:

--- a/deployment/image-service/deployment-image-service.yaml
+++ b/deployment/image-service/deployment-image-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app: image-service
     app.kubernetes.io/component: image-generation
     app.kubernetes.io/name: image-service
-    app.kubernetes.io/part-of: ai-chat
+    app.kubernetes.io/part-of: IMAGE_SERVICES_SUBSYSTEM
     app.openshift.io/runtime: python
 spec:
   replicas: 1
@@ -23,7 +23,7 @@ spec:
       containers:
       - name: image-service
         image: quay.io/mmartofe/ai-chat-image-service:latest
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         ports:
           - name: http
             containerPort: 8100

--- a/static/app.js
+++ b/static/app.js
@@ -320,6 +320,10 @@ createApp({
             await nextTick();
             scrollToBottom();
 
+            const prevGenMsg = [...messages.value].reverse()
+                .find(m => m.role === 'assistant' && m.type === 'image' && m.url);
+            const previousImageUrl = prevGenMsg?.url ?? null;
+
             try {
                 const res = await fetch('/images/generate', {
                     method: 'POST',
@@ -329,6 +333,7 @@ createApp({
                         prompt,
                         width: 1024,
                         height: 576,
+                        previous_image_url: previousImageUrl,
                     }),
                 });
                 if (res.status === 401) { isAuthenticated.value = false; return; }


### PR DESCRIPTION
## Summary

This PR merges the full `dev` branch into `main`. The two most recent commits are:

- **`5769f76`** — fix image FK violation on first action & vision-based iterative image refinement (closes #23, closes #24)
- **`b01df08`** — deployment manifests updated to `imagePullPolicy: Always` to force fresh image pulls from Quay

### Bug fixes (issues #23 & #24)

- **#23** — `image_describe` and `image_generate` now upsert the conversation row (`ON CONFLICT DO NOTHING`) before inserting into `image_generations`, eliminating the FK constraint violation when an image action is the very first thing in a new chat.
- **#24** — `generateImage()` detects the last assistant-generated image in the conversation and passes its URL to the backend as `previous_image_url`; the backend fetches that image, calls the vision model to synthesise a context-aware prompt, and uses it for the next generation — enabling true iterative image refinement without changes to the image service.

### Deployment change

- `imagePullPolicy` changed from `IfNotPresent` to `Always` on the chat-ui, image-service, and vLLM deployments to ensure OpenShift always pulls the latest image from Quay.

## Test plan

- [ ] New chat → `/image a sunset over the ocean` as first action → succeeds (no 500, no FK error)
- [ ] New chat → upload image immediately → analysis succeeds
- [ ] `/image a red car` → `/image make it blue` → second image reflects context from first
- [ ] Regular text chat unaffected
- [ ] Redeployment on OpenShift pulls fresh images

🤖 Generated with [Claude Code](https://claude.com/claude-code)