### PR TITLE
fix context exhaustion — cap LLM input to last 20 messages

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -37,6 +37,7 @@ createApp({
         const currentConvId = ref(null);
         const serverInfo = ref({ model: '', url: '' });
         const lastResponseMs = ref(null);
+        const MAX_CTX_MESSAGES = 20;
 
         // Auth state
         const isImageLoading = ref(false);
@@ -427,7 +428,7 @@ createApp({
                 const response = await fetch('/chat', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ messages: messages.value.slice(0, -1) })
+                    body: JSON.stringify({ messages: messages.value.slice(0, -1).slice(-MAX_CTX_MESSAGES) })
                 });
 
                 if (response.status === 401) {


### PR DESCRIPTION
## Summary

- Fixes HTTP 400 errors that occur when conversation history exceeds the model's 4096-token context window
- Adds a `MAX_CTX_MESSAGES = 20` sliding window constant in `static/app.js`
- The full conversation history remains visible in the UI — only the payload sent to `/chat` is trimmed to the last 20 messages

## Test plan

- [ ] Start a conversation and exchange 25+ messages
- [ ] Confirm no 400 error is returned and the LLM keeps responding
- [ ] Verify the chat UI still shows the full message history (scroll up)
- [ ] Open DevTools → Network → inspect POST `/chat` payload and confirm `messages` array length never exceeds 20

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)