### PR TITLE
fix image service deps — pin torch-incompatible packages for macOS 16

### DIFF
--- a/dev-image.sh
+++ b/dev-image.sh
@@ -8,7 +8,7 @@
 
 cd "$(dirname "$0")/image_service"
 
-python3 -m venv .venv
+python3.12 -m venv .venv
 source .venv/bin/activate
 
 pip install --upgrade pip

--- a/image_service/requirements.txt
+++ b/image_service/requirements.txt
@@ -2,8 +2,8 @@ fastapi
 uvicorn[standard]
 # diffusers>=0.27.0,<0.30.0
 # transformers
-diffusers>=0.30.0
-transformers>=4.41.0
+diffusers>=0.30.0,<0.36.0
+transformers>=4.41.0,<5.0.0
 accelerate
 torch
 numpy<2


### PR DESCRIPTION
## Summary

- Pin `dev-image.sh` to `python3.12` — default `python3` (3.14 on this host) has no torch wheels available
- Cap `diffusers<0.36.0` — 0.36 introduced an unconditional `torch.xpu.empty_cache` reference that crashes at import time on torch 2.2.x
- Cap `transformers<5.0.0` — transformers 5.x requires torch ≥ 2.4 and removed `MT5Tokenizer`; only torch 2.2.2 is available on Darwin 25 (macOS 16)

## Test plan

- [ ] Run `./dev-image.sh` — should install all deps without errors and start uvicorn on port 8100
- [ ] Verify with `image_service/.venv/bin/python -c "import torch; from diffusers import AutoPipelineForText2Image; print(torch.__version__)"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)