### PR TITLE
fix GPU pod scheduling — reduce CPU requests and tune image-vllm memory

### DIFF
--- a/deployment/chat-vllm/k8s/deployment.yaml
+++ b/deployment/chat-vllm/k8s/deployment.yaml
@@ -99,7 +99,7 @@ spec:
               mountPath: ${HF_DIR}
           resources:
             requests:
-              cpu: "2"
+              cpu: "250m"
               memory: "2Gi"
             limits:
               cpu: "3"
@@ -145,7 +145,7 @@ spec:
               protocol: TCP
           resources:
             requests:
-              cpu: "0.5"
+              cpu: "250m"
               memory: "2Gi"
               nvidia.com/gpu: "1"
             limits:

--- a/deployment/image-service/deployment-image-service.yaml
+++ b/deployment/image-service/deployment-image-service.yaml
@@ -41,7 +41,7 @@ spec:
             nvidia.com/gpu: "1"
           requests:
             memory: "4Gi"
-            cpu: "1"
+            cpu: "250m"
             nvidia.com/gpu: "1"
         livenessProbe:
           httpGet:

--- a/deployment/image-vllm/k8s/deployment.yaml
+++ b/deployment/image-vllm/k8s/deployment.yaml
@@ -93,7 +93,7 @@ spec:
               mountPath: ${HF_DIR}
           resources:
             requests:
-              cpu: "2"
+              cpu: "250m"
               memory: "2Gi"
             limits:
               cpu: "3"
@@ -118,11 +118,11 @@ spec:
             - --tensor-parallel-size
             - "1"
             - --max-num-seqs
-            - "128"
+            - "32"
             - --max-model-len
-            - "4096"
+            - "960"
             - --gpu-memory-utilization
-            - "0.9"
+            - "0.95"
             - --enforce-eager
             # --trust-remote-code is a boolean flag (store_true); omitting it means false (the default).
           env:
@@ -139,7 +139,7 @@ spec:
               protocol: TCP
           resources:
             requests:
-              cpu: "0.5"
+              cpu: "250m"
               memory: "2Gi"
             limits:
               cpu: "2"


### PR DESCRIPTION
All 3 GPU worker nodes were at 86-96% CPU utilisation, blocking the pending pods. CPU requests were overstated for GPU-bound workloads so they are lowered across the board to 250m (init and main containers).

image-vllm also crashed on startup: LLaVA-1.5-7B (13.1 GiB) left only 0.48 GiB KV cache on a 15 GiB T4, below the 1 GiB needed for max_model_len=4096. Tuned to fit:
  - max_model_len: 4096 → 960  (T4 hard ceiling ~992 tokens)
  - max_num_seqs:  128   → 32
  - gpu_memory_utilization: 0.9 → 0.95